### PR TITLE
ci: add workflow_dispatch trigger for manual execution #23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
- Enable manual triggering of the CI/CD pipeline via the GitHub Actions UI
- Allow for on-demand testing of build and release logic without code changes