### PR TITLE
feat: add undo functionality with dry-run support and error aggregation

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	minSize    string
 	maxSize   string
 	deleteDupes bool
+	undo       bool
 )
 
 func main() {
@@ -35,6 +36,14 @@ var rootCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1), // Enforces exactly one path argument
 	Run: func(cmd *cobra.Command, args []string) {
 		rootPath := args[0]
+
+		if undo {
+			if err := Undo(rootPath, dryRun); err != nil {
+				log.Fatalf("Undo failed: %v", err)
+			}
+			log.Println("Undo completed successfully.")
+			return
+		}
 
 		if recursive && !force {
 			fmt.Println("WARNING: Recursive mode enabled. This will move files out of their current subdirs")
@@ -111,6 +120,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&minSize, "min-size", "", "Minimum file size (e.g., 100KB, 10MB, 1GB)")
 	rootCmd.PersistentFlags().StringVar(&maxSize, "max-size", "", "Maximum file size (e.g., 100KB, 10MB, 1GB)")
 	rootCmd.PersistentFlags().BoolVarP(&deleteDupes, "delete-dupes", "", false, "Delete duplicate files instead of skipping")
+	rootCmd.PersistentFlags().BoolVar(&undo, "undo", false, "Undo the last organization run and restore original directory structure")
 }
 
 func Execute() {

--- a/organizer.go
+++ b/organizer.go
@@ -48,6 +48,9 @@ type Organizer struct {
 	maxSize int64
 
 	deleteDupes bool
+
+	movedFiles  map[string]string
+	deletedDirs []string
 }
 
 type Metrics struct {
@@ -91,6 +94,8 @@ func NewOrganizer(root string, dryRun bool, recursive bool, logger *slog.Logger,
 		TargetPaths: make(map[string]struct{}),
 		Categories:  make(map[string]map[string]struct{}),
 		deleteDupes: deleteDupes,
+		movedFiles:  make(map[string]string),
+		deletedDirs: []string{},
 	}
 
 	minSize, err := ParseSize(minSizeStr)
@@ -280,6 +285,7 @@ func (o *Organizer) processFile(path string, d fs.DirEntry) error {
 			)
 			return fmt.Errorf("Move failed: %w", err)
 		}
+		o.movedFiles[finalDest] = path
 	}
 
 	o.totalBytes += size
@@ -294,6 +300,27 @@ func (o *Organizer) processFile(path string, d fs.DirEntry) error {
 		)
 	}
 
+	return nil
+}
+
+func (o *Organizer) SaveHistory() error {
+	state := HistoryState{
+		MovedFiles:  o.movedFiles,
+		DeletedDirs: o.deletedDirs,
+		RootPath:    o.RootPath,
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal history state: %w", err)
+	}
+
+	statePath := filepath.Join(o.RootPath, ".fileater-history.json")
+	if err := os.WriteFile(statePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write history file: %w", err)
+	}
+
+	log.Printf("History saved to: %s", statePath)
 	return nil
 }
 
@@ -570,6 +597,13 @@ func (o *Organizer) Run(ctx context.Context) error {
 	}
 
 	fmt.Print(metrics.String())
+
+	if !o.DryRun && len(o.movedFiles) > 0 {
+		if err := o.SaveHistory(); err != nil {
+			log.Printf("Warning: failed to save history file: %v", err)
+		}
+	}
+
 	return err
 }
 
@@ -609,6 +643,7 @@ func (o *Organizer) cleanupEmptyDirs() error {
 
 		if len(entries) == 0 {
 			log.Printf("Removing empty directory: %s", path)
+			o.deletedDirs = append(o.deletedDirs, path)
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				o.Logger.Error("Failed to remove directory",
 					"action", "DELETE_DIR",

--- a/rollback.go
+++ b/rollback.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type HistoryState struct {
+	MovedFiles  map[string]string `json:"moved_files"`
+	DeletedDirs []string         `json:"deleted_dirs"`
+	RootPath    string           `json:"root_path"`
+}
+
+func Undo(rootPath string, dryRun bool) error {
+	statePath := filepath.Join(rootPath, ".fileater-history.json")
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		return fmt.Errorf("history file not found: %s", statePath)
+	}
+
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return fmt.Errorf("failed to read history file: %w", err)
+	}
+
+	var state HistoryState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("failed to parse history file: %w", err)
+	}
+
+	var failures []string
+
+	if dryRun {
+		log.Println("[DRY RUN] Showing what would be restored:")
+	}
+
+	for _, dir := range state.DeletedDirs {
+		if !isSubPath(rootPath, dir) {
+			log.Printf("skipping directory outside root: %s", dir)
+			continue
+		}
+		if dryRun {
+			log.Printf("[DRY RUN] Would recreate directory: %s", dir)
+		} else {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				msg := fmt.Sprintf("failed to recreate directory %s: %v", dir, err)
+				log.Println(msg)
+				failures = append(failures, msg)
+			} else {
+				log.Printf("recreated directory: %s", dir)
+			}
+		}
+	}
+
+	for currentPath, originalPath := range state.MovedFiles {
+		if _, err := os.Stat(currentPath); os.IsNotExist(err) {
+			msg := fmt.Sprintf("current path not found, skipping: %s", currentPath)
+			log.Println(msg)
+			if !dryRun {
+				failures = append(failures, msg)
+			}
+			continue
+		}
+
+		originalDir := filepath.Dir(originalPath)
+		if dryRun {
+			log.Printf("[DRY RUN] Would move %s back to %s", currentPath, originalPath)
+			log.Printf("[DRY RUN] Would create parent directory if needed: %s", originalDir)
+		} else {
+			if err := os.MkdirAll(originalDir, 0755); err != nil {
+				msg := fmt.Sprintf("failed to create parent directory %s: %v", originalDir, err)
+				log.Println(msg)
+				failures = append(failures, msg)
+				continue
+			}
+
+			if err := os.Rename(currentPath, originalPath); err != nil {
+				msg := fmt.Sprintf("failed to move %s back to %s: %v", currentPath, originalPath, err)
+				log.Println(msg)
+				failures = append(failures, msg)
+			} else {
+				log.Printf("moved back: %s -> %s", currentPath, originalPath)
+			}
+		}
+	}
+
+	if !dryRun {
+		if err := os.Remove(statePath); err != nil {
+			log.Printf("warning: failed to delete history file: %v", err)
+		} else {
+			log.Printf("deleted history file: %s", statePath)
+		}
+
+		if len(failures) > 0 {
+			return fmt.Errorf("undo completed with %d failure(s): %v", len(failures), failures)
+		}
+	} else {
+		log.Printf("[DRY RUN] Would delete history file: %s", statePath)
+	}
+
+	return nil
+}
+
+// isSubPath checks if target path is within root path, ensuring proper path boundary
+func isSubPath(root, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+
+	if root == target {
+		return true
+	}
+
+	rootWithSep := root + string(filepath.Separator)
+	return strings.HasPrefix(target, rootWithSep)
+}

--- a/rollback_test.go
+++ b/rollback_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUndo_NoHistoryFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := Undo(tmpDir, false)
+	if err == nil {
+		t.Fatal("expected error when no history file exists")
+	}
+}
+
+func TestUndo_RestoreFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create organized structure
+	docsDir := filepath.Join(tmpDir, "docs")
+	os.MkdirAll(docsDir, 0755)
+
+	originalFile := filepath.Join(tmpDir, "test.txt")
+	movedFile := filepath.Join(docsDir, "test.txt")
+
+	os.WriteFile(originalFile, []byte("content"), 0644)
+	os.Rename(originalFile, movedFile)
+
+	// Create history file
+	state := HistoryState{
+		MovedFiles: map[string]string{
+			movedFile: originalFile,
+		},
+		DeletedDirs: []string{},
+		RootPath:    tmpDir,
+	}
+
+	data, _ := json.MarshalIndent(state, "", "  ")
+	os.WriteFile(filepath.Join(tmpDir, ".fileater-history.json"), data, 0644)
+
+	// Run undo
+	if err := Undo(tmpDir, false); err != nil {
+		t.Fatalf("Undo failed: %v", err)
+	}
+
+	// Verify file is back
+	if _, err := os.Stat(originalFile); os.IsNotExist(err) {
+		t.Error("original file was not restored")
+	}
+	if _, err := os.Stat(movedFile); !os.IsNotExist(err) {
+		t.Error("moved file should be gone")
+	}
+
+	// Verify history file is deleted
+	if _, err := os.Stat(filepath.Join(tmpDir, ".fileater-history.json")); !os.IsNotExist(err) {
+		t.Error("history file should be deleted after undo")
+	}
+}
+
+func TestUndo_RestoreDeletedDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create and delete a directory to simulate cleanup
+	deletedDir := filepath.Join(tmpDir, "old_subdir")
+	os.MkdirAll(deletedDir, 0755)
+	os.Remove(deletedDir)
+
+	// Create history file with deleted dir
+	state := HistoryState{
+		MovedFiles: map[string]string{},
+		DeletedDirs: []string{deletedDir},
+		RootPath:    tmpDir,
+	}
+
+	data, _ := json.MarshalIndent(state, "", "  ")
+	os.WriteFile(filepath.Join(tmpDir, ".fileater-history.json"), data, 0644)
+
+	// Run undo
+	if err := Undo(tmpDir, false); err != nil {
+		t.Fatalf("Undo failed: %v", err)
+	}
+
+	// Verify directory is recreated
+	if _, err := os.Stat(deletedDir); os.IsNotExist(err) {
+		t.Error("deleted directory was not recreated")
+	}
+}
+
+func TestUndo_MissingSourceFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create history file pointing to non-existent file
+	state := HistoryState{
+		MovedFiles: map[string]string{
+			filepath.Join(tmpDir, "docs", "nonexistent.txt"): filepath.Join(tmpDir, "nonexistent.txt"),
+		},
+		DeletedDirs: []string{},
+		RootPath:    tmpDir,
+	}
+
+	data, _ := json.MarshalIndent(state, "", "  ")
+	os.WriteFile(filepath.Join(tmpDir, ".fileater-history.json"), data, 0644)
+
+	// Should return error since source file is missing
+	err := Undo(tmpDir, false)
+	if err == nil {
+		t.Fatal("expected error when source file is missing")
+	}
+}
+
+func TestUndo_InvalidHistoryFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write invalid JSON
+	os.WriteFile(filepath.Join(tmpDir, ".fileater-history.json"), []byte("invalid json"), 0644)
+
+	err := Undo(tmpDir, false)
+	if err == nil {
+		t.Fatal("expected error for invalid history file")
+	}
+}
+
+func TestSaveHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	o, _ := NewOrganizer(tmpDir, false, false, newTestLogger(), "", "", false)
+	o.movedFiles = map[string]string{
+		filepath.Join(tmpDir, "docs", "file.txt"): filepath.Join(tmpDir, "file.txt"),
+	}
+	o.deletedDirs = []string{filepath.Join(tmpDir, "emptydir")}
+
+	// Run to trigger SaveHistory
+	o.Run(ctx)
+
+	// Verify history file exists
+	statePath := filepath.Join(tmpDir, ".fileater-history.json")
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		t.Fatal("history file was not created")
+	}
+
+	// Verify content
+	data, _ := os.ReadFile(statePath)
+	var state HistoryState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("failed to parse history file: %v", err)
+	}
+
+	if len(state.MovedFiles) != 1 {
+		t.Errorf("expected 1 moved file, got %d", len(state.MovedFiles))
+	}
+	if len(state.DeletedDirs) != 1 {
+		t.Errorf("expected 1 deleted dir, got %d", len(state.DeletedDirs))
+	}
+}
+
+func TestUndo_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create organized structure
+	docsDir := filepath.Join(tmpDir, "docs")
+	os.MkdirAll(docsDir, 0755)
+
+	originalFile := filepath.Join(tmpDir, "test.txt")
+	movedFile := filepath.Join(docsDir, "test.txt")
+
+	os.WriteFile(originalFile, []byte("content"), 0644)
+	os.Rename(originalFile, movedFile)
+
+	// Create history file
+	state := HistoryState{
+		MovedFiles: map[string]string{
+			movedFile: originalFile,
+		},
+		DeletedDirs: []string{filepath.Join(tmpDir, "olddir")},
+		RootPath:    tmpDir,
+	}
+
+	data, _ := json.MarshalIndent(state, "", "  ")
+	os.WriteFile(filepath.Join(tmpDir, ".fileater-history.json"), data, 0644)
+
+	// Run undo with dryRun=true
+	if err := Undo(tmpDir, true); err != nil {
+		t.Fatalf("Dry-run Undo failed: %v", err)
+	}
+
+	// Verify file is NOT back (dry run should not move)
+	if _, err := os.Stat(originalFile); !os.IsNotExist(err) {
+		t.Error("original file should NOT be restored in dry-run mode")
+	}
+	if _, err := os.Stat(movedFile); os.IsNotExist(err) {
+		t.Error("moved file should still exist in dry-run mode")
+	}
+
+	// Verify history file is NOT deleted
+	if _, err := os.Stat(filepath.Join(tmpDir, ".fileater-history.json")); os.IsNotExist(err) {
+		t.Error("history file should NOT be deleted in dry-run mode")
+	}
+}


### PR DESCRIPTION
- Implement 'Undo' logic in rollback.go to restore files using state history
- Add '--undo' flag to main.go to trigger the restoration process
- Support '--dryrun' in undo mode to preview changes without moving files
- Implement error aggregation to ensure the CLI exits with a non-zero code on failures
- Add 'SaveHistory' to organizer.go to persist state after successful runs
- Add comprehensive tests in rollback_test.go covering dry-runs and edge cases