### PR TITLE
fix: add contents write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
- GITHUB_TOKEN needs explicit permission to create releases
- Add permissions: contents: write at workflow level